### PR TITLE
delete unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ log = { version = "0.4.16", default_features = false }
 packing = "0.2.0"
 usbd_scsi = "0.1.0"
 bitflags = "1.3.2"
-bytes = { version = "1.1.0", default_features = false }
+#bytes = { version = "1.1.0", default_features = false }
 
 [dev-dependencies]
 fatfs = "0.3.5"


### PR DESCRIPTION
bytes.rs is never used but create errors on targets without atomics(arm-thumb-v6m) 
https://github.com/tokio-rs/bytes/issues/461